### PR TITLE
Update to HSL-based color sorting

### DIFF
--- a/color_lightness_quiz_v0.4.html
+++ b/color_lightness_quiz_v0.4.html
@@ -49,17 +49,19 @@
     const solutionContainer = document.getElementById('solution-container');
     let correctOrder = [];
 
-    function generateRandomColor() {
-      const r = Math.floor(Math.random() * 256);
-      const g = Math.floor(Math.random() * 256);
-      const b = Math.floor(Math.random() * 256);
-      return `rgb(${r}, ${g}, ${b})`;
-    }
+      // Generate a random color in HSL format
+      function generateRandomColor() {
+        const h = Math.floor(Math.random() * 360);
+        const s = Math.floor(Math.random() * 101);
+        const l = Math.floor(Math.random() * 101);
+        return `hsl(${h}, ${s}%, ${l}%)`;
+      }
 
-    function getLightness(rgb) {
-      const [r, g, b] = rgb.match(/\d+/g).map(Number);
-      return 0.2126 * r + 0.7152 * g + 0.0722 * b;
-    }
+      // Extract the lightness value from an HSL color string
+      function getLightness(hsl) {
+        const [, , l] = hsl.match(/\d+/g).map(Number);
+        return l;
+      }
 
     function generateColors() {
       result.textContent = "";


### PR DESCRIPTION
## Summary
- use random HSL colors
- extract lightness from HSL strings when sorting

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6882736416508326b6445313553a9fd4