### PR TITLE
Fix color generation unique lightness

### DIFF
--- a/color_lightness_quiz_v0.4.html
+++ b/color_lightness_quiz_v0.4.html
@@ -68,10 +68,15 @@
       solutionContainer.innerHTML = "";
       colorContainer.innerHTML = "";
       let colors = [];
+      const usedLightness = new Set();
 
       while (colors.length < 6) {
         let color = generateRandomColor();
-        if (!colors.includes(color)) colors.push(color);
+        const l = getLightness(color);
+        if (!colors.includes(color) && !usedLightness.has(l)) {
+          colors.push(color);
+          usedLightness.add(l);
+        }
       }
 
       correctOrder = [...colors].sort((a, b) => getLightness(a) - getLightness(b));


### PR DESCRIPTION
## Summary
- ensure `generateColors` rejects colors with duplicate lightness

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688277e3c0548326aeafc4a929eb330b